### PR TITLE
Creating Unit of Work

### DIFF
--- a/Psalms.EFCore.DataManager/Psalms.EFCore.DataManager.csproj
+++ b/Psalms.EFCore.DataManager/Psalms.EFCore.DataManager.csproj
@@ -1,13 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-  </ItemGroup>
+		<PackageId>Psalms.EFCore.DataManagement</PackageId>
+		<Version>1.0.0</Version>
+		<Authors>Psalms Library</Authors>
+		<Company>Psalms Library</Company>
+		<Description>A clean, extensible Repository and Unit of Work library for Entity Framework Core and other providers.</Description>
+		<PackageTags>repository unitofwork efcore</PackageTags>
+		<RepositoryUrl>https://github.com/PsalmsLibrary/Psalsm.EFCore.DataManager</RepositoryUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+	</ItemGroup>
 
 </Project>

--- a/Psalms.EFCore.DataManager/UnitOfWork/IPsalmsUnitOfWork.cs
+++ b/Psalms.EFCore.DataManager/UnitOfWork/IPsalmsUnitOfWork.cs
@@ -1,0 +1,23 @@
+﻿using Psalms.EFCore.DataManager.Repository;
+
+namespace Psalms.EFCore.DataManager.UnitOfWork;
+
+/// <summary>
+/// Represents a unit of work pattern, which coordinates repositories and commits changes.
+/// </summary>
+/// <typeparam name="TContext">The type of DbContext in use.</typeparam>
+public interface IPsalmsUnitOfWork<TContext> 
+{
+    /// <summary>
+    /// The generic repository used for data access.
+    /// </summary>
+    IPsalmsEfCoreRepository Repository { get; }
+
+    /// <summary>
+    /// Commits all pending changes to the database.
+    /// </summary>
+    Task<int> SaveChangesAsync();
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync();
+}

--- a/Psalms.EFCore.DataManager/UnitOfWork/PsalmsUnitOfWork.cs
+++ b/Psalms.EFCore.DataManager/UnitOfWork/PsalmsUnitOfWork.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Psalms.EFCore.DataManager.Repository;
+
+namespace Psalms.EFCore.DataManager.UnitOfWork;
+
+/// <summary>
+/// Default implementation of the Unit of Work pattern using Entity Framework.
+/// Encapsulates the DbContext and coordinates data access through the repository.
+/// </summary>
+/// <typeparam name="TContext">The type of DbContext to use.</typeparam>
+public class PsalmsUnitOfWork<TContext> : IPsalmsUnitOfWork<TContext>, IAsyncDisposable where TContext : DbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>
+    /// The generic repository instance for entity operations.
+    /// </summary>
+    public IPsalmsEfCoreRepository Repository { get; private init; }
+
+    /// <summary>
+    /// Initializes a new instance of the Unit of Work with the default repository.
+    /// </summary>
+    public PsalmsUnitOfWork(TContext context)
+    {
+        _context = context;
+        Repository = new PsalmsEfCoreRepository(context);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the Unit of Work with a custom repository.
+    /// </summary>
+    public PsalmsUnitOfWork(TContext context, IPsalmsEfCoreRepository specifiedRepository) : this(context)
+        => Repository = specifiedRepository ?? throw new ArgumentNullException(nameof(specifiedRepository));
+
+    /// <inheritdoc />
+    public Task<int> SaveChangesAsync() => _context.SaveChangesAsync();
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _context.DisposeAsync();
+}

--- a/Psalms.EFCore.DataManagerTests/PsalmsUnitOfWorkTests.cs
+++ b/Psalms.EFCore.DataManagerTests/PsalmsUnitOfWorkTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Psalms.EFCore.DataManager.UnitOfWork;
+
+namespace Psalms.EFCore.DataManagerTests;
+
+public class PsalmsUnitOfWorkTests
+{
+    private static TestDbContext GetDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    [Fact]
+    public void Constructor_Should_Initialize_Repository()
+    {
+        // Arrange
+        var context = GetDbContext(nameof(Constructor_Should_Initialize_Repository));
+
+        // Act
+        var uow = new PsalmsUnitOfWork<TestDbContext>(context);
+
+        // Assert
+        Assert.NotNull(uow.Repository);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_Should_Persist_Data()
+    {
+        // Arrange
+        var context = GetDbContext(nameof(SaveChangesAsync_Should_Persist_Data));
+        var uow = new PsalmsUnitOfWork<TestDbContext>(context);
+
+        var entity = new Product { Id = 1, Name = "Test Product" };
+
+        // Act
+        await uow.Repository.CreateAsync(entity);
+        var result = await uow.SaveChangesAsync();
+
+        // Assert
+        Assert.Equal(1, result);
+        Assert.Single(context.Products);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Should_Dispose_DbContext()
+    {
+        // Arrange
+        var context = GetDbContext(nameof(DisposeAsync_Should_Dispose_DbContext));
+        var uow = new PsalmsUnitOfWork<TestDbContext>(context);
+
+        // Act
+        await uow.DisposeAsync();
+
+        // Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => context.Products.ToListAsync());
+    }
+}


### PR DESCRIPTION
# ✨ Added PsalmsUnitOfWork and IPsalmsUnitOfWork

## 📋 Summary
This PR introduces the **Unit of Work** pattern implementation for Entity Framework Core, providing a centralized way to manage transactions and repository access.

---

## 🗂 Changes Introduced
- **Created** `IPsalmsUnitOfWork<TContext>` interface:
  - Defines the contract for the Unit of Work.
  - Exposes:
    - A generic `IPsalmsEfCoreRepository` for data access.
    - `SaveChangesAsync` method for committing transactions.
    - `DisposeAsync` for resource cleanup.

- **Implemented** `PsalmsUnitOfWork<TContext> class:
  - Accepts a `DbContext` and initializes the repository.
  - Supports a default repository or a custom implementation.
  - Implements `IAsyncDisposable` for proper `DbContext` disposal.
  - Keeps database save operations explicit via `SaveChangesAsync`.

---

## ⚙️ Technical Details
- **Generic Context Support**: Works with any class derived from `DbContext`.
- **Repository Integration**: Tightly coupled with `PsalmsEfCoreRepository` for EF Core operations.
- **Dependency Injection Friendly**: Can be registered in DI with scoped lifetime.

---

## 💻 Example Usage
```csharp
services.AddScoped<IPsalmsUnitOfWork<AppDbContext>, PsalmsUnitOfWork<AppDbContext>>();

public class ProductService
{
    private readonly IPsalmsUnitOfWork<AppDbContext> _uow;

    public ProductService(IPsalmsUnitOfWork<AppDbContext> uow)
    {
        _uow = uow;
    }

    public async Task AddProductAsync(Product product)
    {
        await _uow.Repository.CreateAsync(product);
        await _uow.SaveChangesAsync();
    }
}
